### PR TITLE
use public path to dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,18 +5,17 @@ gemspec
 
 gem 'coveralls', require: false
 
-gem 'llt-core', git: 'git@github.com:latin-language-toolkit/llt-core.git'
-gem 'llt-core_extensions', git: 'git@github.com:latin-language-toolkit/llt-core_extensions.git'
-gem 'llt-constants', git: 'git@github.com:latin-language-toolkit/llt-constants.git'
-gem 'llt-db_handler', git: 'git@github.com:latin-language-toolkit/llt-db_handler.git'
-gem 'llt-helpers', git: 'git@github.com:latin-language-toolkit/llt-helpers.git'
+gem 'llt-core', git: 'https://github.com/latin-language-toolkit/llt-core.git'
+gem 'llt-constants', git: 'https://github.com/latin-language-toolkit/llt-constants.git'
+gem 'llt-db_handler', git: 'https://github.com/latin-language-toolkit/llt-db_handler.git'
+gem 'llt-helpers', git: 'https://github.com/latin-language-toolkit/llt-helpers.git'
 gem 'llt-logger', git: 'https://github.com/latin-language-toolkit/llt-logger.git'
 gem 'llt-segmenter', git: 'https://github.com/latin-language-toolkit/llt-segmenter.git'
 gem 'llt-tokenizer', git: 'https://github.com/latin-language-toolkit/llt-tokenizer.git'
 
 # Dependencies of db_handler
-gem 'llt-core_extensions', git: 'git@github.com:latin-language-toolkit/llt-core_extensions.git'
-gem 'llt-form_builder', git: 'git@github.com:latin-language-toolkit/llt-form_builder.git'
+gem 'llt-core_extensions', git: 'https://github.com/latin-language-toolkit/llt-core_extensions.git'
+gem 'llt-form_builder', git: 'https://github.com/latin-language-toolkit/llt-form_builder.git'
 
 platform :ruby do
   gem 'pg'


### PR DESCRIPTION
Forgot to mention in the commit message that core-extensions was also included twice - I removed the first reference
